### PR TITLE
Add support for marker-specific typing thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
     - name: Code checkout
       uses: actions/checkout@v4
     - name: Run tests
-      run: make testcov
+      run: |
+        cargo binstall llvm-cov
+        make testcov
     - name: Check style
       run: make style
     - name: Count lines of code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Code checkout
       uses: actions/checkout@v4
     - name: Run tests
-      run: make test
+      run: make testcov
     - name: Check style
       run: make style
     - name: Count lines of code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
       run: make test
     - name: Check style
       run: make style
+    - name: Count lines of code
+      run:
+        - cargo install cargo-warloc
+        - make style
     - name: Compile release binary
       run: make release
     - name: Binary upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Count lines of code
       run: |
         cargo install cargo-warloc
-        make style
+        make loc
     - name: Compile release binary
       run: make release
     - name: Binary upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Run tests
       run: |
         cargo install cargo-llvm-cov
-        make testcov
+        make testcov | tee coverage.txt
     - name: Check style
       run: make style
     - name: Count lines of code
@@ -35,4 +35,5 @@ jobs:
         name: mhrs
         path: |
           target/release/mhrs
+          coverage.txt
           warloc.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Run tests
       run: |
-        cargo binstall llvm-cov
+        cargo install cargo-llvm-cov
         make testcov
     - name: Check style
       run: make style

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,13 @@ jobs:
     - name: Count lines of code
       run: |
         cargo install cargo-warloc
-        make loc
+        make loc | tee warloc.txt
     - name: Compile release binary
       run: make release
     - name: Binary upload
       uses: actions/upload-artifact@v4.6.2
       with:
         name: mhrs
-        path: target/release/mhrs
+        path: |
+          target/release/mhrs
+          warloc.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
     - name: Check style
       run: make style
     - name: Count lines of code
-      run:
-        - cargo install cargo-warloc
-        - make style
+      run: |
+        cargo install cargo-warloc
+        make style
     - name: Compile release binary
       run: make release
     - name: Binary upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: CI
 
 on:
   push:
@@ -15,14 +15,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Code checkout
+      uses: actions/checkout@v4
     - name: Run tests
       run: make test
     - name: Check style
       run: make style
     - name: Compile release binary
       run: make release
-    - uses: actions/upload-artifact@v4.6.2
+    - name: Binary upload
+      uses: actions/upload-artifact@v4.6.2
       with:
         name: mhrs
         path: target/release/mhrs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +293,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +418,27 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -359,6 +509,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfae20f6b19ad527b550c223fddc3077a547fc70cda94b9b566575423fd303ee"
 
 [[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+
+[[package]]
 name = "lzma-sys"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +538,7 @@ dependencies = [
  "clap",
  "counter",
  "csv",
+ "idna 1.0.3",
  "itertools",
  "rust-htslib",
  "serde",
@@ -575,6 +732,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +785,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +813,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -678,9 +868,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -759,3 +961,82 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+ "synstructure",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 clap = { version = "4.5", features = ["derive"] }
 counter = "0.5.*"
 csv = "1.3.*"
+idna = "1.0.3"
 itertools = "0.10.*"
 rust-htslib = "0.46.*"
 serde = { version = "1.0", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 
 ## testcov:     run test suite and show test coverage
 testcov:
-	cargo llvm-cov --show-missing-lines
+	cargo llvm-cov --show-missing-lines --ignore-filename-regex 'src/(main|cli).rs'
 
 ## style:       check code style
 style:

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ style:
 format:
 	cargo fmt
 
+## loc   :      count lines of code
+loc:
+	cargo warloc
+
 ## release:     compile release binary
 release:
 	cargo build --release

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -2,6 +2,8 @@ use crate::caller::HaplotypeCaller;
 use crate::observer::HaplotypeObserver;
 use crate::panel::MicrohapPanel;
 use crate::profile::MicrohapProfile;
+use csv::ReaderBuilder;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 pub struct MicrohapAnalyzer {
@@ -32,8 +34,8 @@ impl MicrohapAnalyzer {
             );
             let mut caller = HaplotypeCaller::from_observer(&observer);
             let result = caller.apply_filters(
-                self.parameters.detection_threshold,
-                self.parameters.analytical_threshold,
+                self.parameters.detection_threshold.global,
+                self.parameters.analytical_threshold.global,
             );
             self.profile.add(mhid, result);
         }
@@ -45,8 +47,8 @@ impl MicrohapAnalyzer {
 }
 
 pub struct TypingParameters {
-    pub detection_threshold: u16,
-    pub analytical_threshold: f64,
+    pub detection_threshold: DetectionThreshold,
+    pub analytical_threshold: AnalyticalThreshold,
     pub min_base_quality: u8,
     pub max_depth: u32,
 }
@@ -54,10 +56,81 @@ pub struct TypingParameters {
 impl TypingParameters {
     pub fn defaults() -> TypingParameters {
         TypingParameters {
-            detection_threshold: 10,
-            analytical_threshold: 0.04,
+            detection_threshold: DetectionThreshold::new(10),
+            analytical_threshold: AnalyticalThreshold::new(0.04),
             min_base_quality: 10,
             max_depth: 1e6 as u32,
+        }
+    }
+
+    pub fn new(
+        detection_global: u16,
+        analytical_global: f64,
+        min_base_quality: u8,
+        max_depth: u32,
+        thresholds_file: Option<&PathBuf>,
+    ) -> TypingParameters {
+        let mut params = TypingParameters {
+            detection_threshold: DetectionThreshold::new(detection_global),
+            analytical_threshold: AnalyticalThreshold::new(analytical_global),
+            min_base_quality,
+            max_depth,
+        };
+        match thresholds_file {
+            None => (),
+            Some(csv_path) => params.parse_thresholds_csv(csv_path),
+        };
+
+        params
+    }
+
+    fn parse_thresholds_csv(&mut self, csv_path: &PathBuf) {
+        let mut reader = ReaderBuilder::new()
+            .from_path(csv_path)
+            .expect("error parsing CSV file");
+        for result in reader.records() {
+            let record = result.expect("error parsing CSV record");
+            let marker = &record[0];
+            let static_th = record[1]
+                .parse::<u16>()
+                .expect("error parsing detection threshold");
+            let dynamic_th = record[2]
+                .parse::<f64>()
+                .expect("error parsing analytical threshold");
+            self.detection_threshold
+                .by_marker
+                .insert(marker.to_string(), static_th);
+            self.analytical_threshold
+                .by_marker
+                .insert(marker.to_string(), dynamic_th);
+        }
+    }
+}
+
+pub struct DetectionThreshold {
+    pub global: u16,
+    pub by_marker: HashMap<String, u16>,
+}
+
+impl DetectionThreshold {
+    pub fn new(global: u16) -> DetectionThreshold {
+        DetectionThreshold {
+            global,
+            by_marker: HashMap::new(),
+        }
+    }
+}
+
+pub struct AnalyticalThreshold {
+    pub global: f64,
+    pub by_marker: HashMap<String, f64>,
+}
+
+impl AnalyticalThreshold {
+    pub fn new(global: f64) -> AnalyticalThreshold {
+        AnalyticalThreshold {
+            global,
+            by_marker: HashMap::new(),
         }
     }
 }

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1,9 +1,8 @@
 use crate::caller::HaplotypeCaller;
 use crate::observer::HaplotypeObserver;
 use crate::panel::MicrohapPanel;
+use crate::parameters::TypingParameters;
 use crate::profile::MicrohapProfile;
-use csv::ReaderBuilder;
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 pub struct MicrohapAnalyzer {
@@ -33,104 +32,14 @@ impl MicrohapAnalyzer {
                 self.parameters.max_depth,
             );
             let mut caller = HaplotypeCaller::from_observer(&observer);
-            let result = caller.apply_filters(
-                self.parameters.detection_threshold.global,
-                self.parameters.analytical_threshold.global,
-            );
+            let detection = self.parameters.detection_threshold.get(mhid);
+            let analytical = self.parameters.analytical_threshold.get(mhid);
+            let result = caller.apply_filters(detection, analytical);
             self.profile.add(mhid, result);
         }
     }
 
     pub fn final_profile(&self) -> &MicrohapProfile {
         &self.profile
-    }
-}
-
-pub struct TypingParameters {
-    pub detection_threshold: DetectionThreshold,
-    pub analytical_threshold: AnalyticalThreshold,
-    pub min_base_quality: u8,
-    pub max_depth: u32,
-}
-
-impl TypingParameters {
-    pub fn defaults() -> TypingParameters {
-        TypingParameters {
-            detection_threshold: DetectionThreshold::new(10),
-            analytical_threshold: AnalyticalThreshold::new(0.04),
-            min_base_quality: 10,
-            max_depth: 1e6 as u32,
-        }
-    }
-
-    pub fn new(
-        detection_global: u16,
-        analytical_global: f64,
-        min_base_quality: u8,
-        max_depth: u32,
-        thresholds_file: Option<&PathBuf>,
-    ) -> TypingParameters {
-        let mut params = TypingParameters {
-            detection_threshold: DetectionThreshold::new(detection_global),
-            analytical_threshold: AnalyticalThreshold::new(analytical_global),
-            min_base_quality,
-            max_depth,
-        };
-        match thresholds_file {
-            None => (),
-            Some(csv_path) => params.parse_thresholds_csv(csv_path),
-        };
-
-        params
-    }
-
-    fn parse_thresholds_csv(&mut self, csv_path: &PathBuf) {
-        let mut reader = ReaderBuilder::new()
-            .from_path(csv_path)
-            .expect("error parsing CSV file");
-        for result in reader.records() {
-            let record = result.expect("error parsing CSV record");
-            let marker = &record[0];
-            let static_th = record[1]
-                .parse::<u16>()
-                .expect("error parsing detection threshold");
-            let dynamic_th = record[2]
-                .parse::<f64>()
-                .expect("error parsing analytical threshold");
-            self.detection_threshold
-                .by_marker
-                .insert(marker.to_string(), static_th);
-            self.analytical_threshold
-                .by_marker
-                .insert(marker.to_string(), dynamic_th);
-        }
-    }
-}
-
-pub struct DetectionThreshold {
-    pub global: u16,
-    pub by_marker: HashMap<String, u16>,
-}
-
-impl DetectionThreshold {
-    pub fn new(global: u16) -> DetectionThreshold {
-        DetectionThreshold {
-            global,
-            by_marker: HashMap::new(),
-        }
-    }
-}
-
-pub struct AnalyticalThreshold {
-    pub global: f64,
-    pub by_marker: HashMap<String, f64>,
-}
-
-impl AnalyticalThreshold {
-    pub fn new(global: f64) -> AnalyticalThreshold {
-        AnalyticalThreshold {
-            global,
-            by_marker: HashMap::new(),
-        }
     }
 }

--- a/src/caller.rs
+++ b/src/caller.rs
@@ -5,7 +5,8 @@ extern crate serde_json;
 use crate::counter::ReadHapCounter;
 use crate::observer::HaplotypeObserver;
 use crate::read::ReadHaplotype;
-use crate::result::{TypingCoverage, TypingResult, TypingThresholds};
+use crate::result::{TypingCoverage, TypingResult};
+use crate::thresholds::TypingThresholds;
 use counter::Counter;
 
 pub struct HaplotypeCaller {
@@ -40,8 +41,9 @@ impl HaplotypeCaller {
         genotype.sort();
 
         let thresholds = TypingThresholds {
-            dynamic_analytical: analy,
-            static_detection: detect,
+            dynamic: analytical,
+            analytical: analy,
+            detection: detect,
         };
         let counts = ReadHapCounter {
             tally: self.raw_counts.clone(),

--- a/src/caller.rs
+++ b/src/caller.rs
@@ -80,7 +80,7 @@ mod tests {
 
     fn init_caller() -> HaplotypeCaller {
         let def = AlleleDefinition::from_vector(
-            "chr22".to_string(),
+            "chr22",
             vec![48665164, 48665175, 48665182, 48665204, 48665216],
         );
         let mut observer = HaplotypeObserver::new(&def);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,6 +38,14 @@ pub struct Cli {
     pub analytical_threshold: f64,
 
     #[arg(
+        short = 't',
+        long = "threshold-csv",
+        value_name = "TC",
+        help = "CSV file with marker-specific thresholds; column 1 = marker name, column 2 = detection, column 3 = analytical"
+    )]
+    pub threshold_csv: Option<PathBuf>,
+
+    #[arg(
         short = 'b',
         long = "base-qual",
         value_name = "BQ",
@@ -54,12 +62,4 @@ pub struct Cli {
         help = "Maximum per-base read depth"
     )]
     pub max_depth: u32,
-
-    #[arg(
-        short = 't',
-        long = "threshold-csv",
-        value_name = "TC",
-        help = "CSV file with marker-specific thresholds; column 1 = marker name, column 2 = detection, column 3 = analytical"
-    )]
-    pub threshold_csv: Option<PathBuf>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,4 +45,13 @@ pub struct Cli {
         help = "Minimum base quality for read haplotype calling"
     )]
     pub min_base_quality: u8,
+
+    #[arg(
+        short = 'x',
+        long = "max-depth",
+        value_name = "MD",
+        default_value = "1000000",
+        help = "Maximum per-base read depth"
+    )]
+    pub max_depth: u32,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,3 +63,19 @@ pub struct Cli {
     )]
     pub max_depth: u32,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cli_defaults() {
+        let arglist = vec!["mhrs", "testdata/mwgfour.csv", "testdata/mwgfour-p1p3.bam"];
+        let args = Cli::parse_from(arglist);
+        assert_eq!(args.csv, PathBuf::from("testdata/mwgfour.csv"));
+        assert_eq!(args.bam, PathBuf::from("testdata/mwgfour-p1p3.bam"));
+        assert_eq!(args.detection_threshold, 10);
+        assert_eq!(args.analytical_threshold, 0.04);
+        assert!(args.threshold_csv.is_none());
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,4 +54,12 @@ pub struct Cli {
         help = "Maximum per-base read depth"
     )]
     pub max_depth: u32,
+
+    #[arg(
+        short = 't',
+        long = "threshold-csv",
+        value_name = "TC",
+        help = "CSV file with marker-specific thresholds; column 1 = marker name, column 2 = detection, column 3 = analytical"
+    )]
+    pub threshold_csv: Option<PathBuf>,
 }

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -8,9 +8,9 @@ pub struct AlleleDefinition {
 }
 
 impl AlleleDefinition {
-    pub fn new(chromosome: String) -> AlleleDefinition {
+    pub fn new(chromosome: &str) -> AlleleDefinition {
         AlleleDefinition {
-            chromosome,
+            chromosome: chromosome.to_string(),
             offsets: Vec::new(),
             indices: HashMap::new(),
         }
@@ -60,7 +60,7 @@ mod tests {
     use super::*;
 
     impl AlleleDefinition {
-        pub fn from_vector(chromosome: String, mut offsets: Vec<u32>) -> AlleleDefinition {
+        pub fn from_vector(chromosome: &str, mut offsets: Vec<u32>) -> AlleleDefinition {
             offsets.sort();
             let indices = offsets
                 .iter()
@@ -68,7 +68,7 @@ mod tests {
                 .map(|(index, &offset)| (offset, index))
                 .collect();
             AlleleDefinition {
-                chromosome,
+                chromosome: chromosome.to_string(),
                 offsets,
                 indices,
             }
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn test_definition_basic() {
-        let mut def = AlleleDefinition::new("chr18".to_string());
+        let mut def = AlleleDefinition::new("chr18");
         assert_eq!(def.extent(), 0);
         def.add_snp_offset(53008000);
         def.add_snp_offset(53008025);
@@ -108,8 +108,7 @@ mod tests {
 
     #[test]
     fn test_definition_construct_from_vector() {
-        let def =
-            AlleleDefinition::from_vector("chr13".to_string(), vec![29218045, 29218056, 29218077]);
+        let def = AlleleDefinition::from_vector("chr13", vec![29218045, 29218056, 29218077]);
         assert_eq!(def.extent(), 33);
         assert_eq!(def.num_snps(), 3);
     }
@@ -117,7 +116,7 @@ mod tests {
     #[test]
     fn test_coordinates() {
         let def = AlleleDefinition::from_vector(
-            "chr5".to_string(),
+            "chr5",
             vec![
                 31094962, 31095011, 31095136, 31095187, 31095193, 31095262, 31095306,
             ],

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
         detection_threshold: args.detection_threshold,
         analytical_threshold: args.analytical_threshold,
         min_base_quality: args.min_base_quality,
-        max_depth: 1e6 as u32,
+        max_depth: args.max_depth,
     };
     analyzer.process(&args.bam);
     println!("{}", analyzer.final_profile().to_json());

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,12 +16,13 @@ use cli::Cli;
 fn main() {
     let args = Cli::parse();
     let mut analyzer = MicrohapAnalyzer::new(&args.sample, &args.csv);
-    analyzer.parameters = TypingParameters {
-        detection_threshold: args.detection_threshold,
-        analytical_threshold: args.analytical_threshold,
-        min_base_quality: args.min_base_quality,
-        max_depth: args.max_depth,
-    };
+    analyzer.parameters = TypingParameters::new(
+        args.detection_threshold,
+        args.analytical_threshold,
+        args.min_base_quality,
+        args.max_depth,
+        args.threshold_csv.as_ref(),
+    );
     analyzer.process(&args.bam);
     println!("{}", analyzer.final_profile().to_json());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,13 +5,16 @@ mod counter;
 mod definition;
 mod observer;
 mod panel;
+mod parameters;
 mod profile;
 mod read;
 mod result;
+mod thresholds;
 
-use analyzer::{MicrohapAnalyzer, TypingParameters};
+use analyzer::MicrohapAnalyzer;
 use clap::Parser;
 use cli::Cli;
+use parameters::TypingParameters;
 
 fn main() {
     let args = Cli::parse();

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -23,11 +23,11 @@ impl HaplotypeObserver {
         }
     }
 
-    pub fn set(&mut self, read_name: String, offset: u32, base: char) {
+    pub fn set(&mut self, read_name: &str, offset: u32, base: char) {
         let num_snps = self.definition.num_snps();
         let readhap = self
             .index
-            .entry(read_name)
+            .entry(read_name.to_string())
             .or_insert(ReadHaplotype::new(num_snps));
         let index = match self.definition.get_index(offset) {
             Some(i) => i,
@@ -96,7 +96,7 @@ impl HaplotypeObserver {
                         false => record.seq()[qpos] as char,
                     };
                     let read_name = std::str::from_utf8(record.qname()).unwrap();
-                    self.set(read_name.to_string(), refr_pos, allele);
+                    self.set(read_name, refr_pos, allele);
                 }
             }
         }
@@ -138,7 +138,7 @@ mod tests {
     #[test]
     fn test_observer_basic() {
         let def = AlleleDefinition::from_vector(
-            "chr22".to_string(),
+            "chr22",
             vec![48665164, 48665175, 48665182, 48665204, 48665216],
         );
         let mut observer = HaplotypeObserver::new(&def);
@@ -158,10 +158,10 @@ mod tests {
     #[should_panic(expected = "invalid offset: 12345")]
     fn test_observer_set_bad_offset() {
         let def = AlleleDefinition::from_vector(
-            "chr22".to_string(),
+            "chr22",
             vec![48665164, 48665175, 48665182, 48665204, 48665216],
         );
         let mut observer = HaplotypeObserver::new(&def);
-        observer.set("read42".to_string(), 12345, 'C');
+        observer.set("read42", 12345, 'C');
     }
 }

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -164,4 +164,15 @@ mod tests {
         let mut observer = HaplotypeObserver::new(&def);
         observer.set("read42", 12345, 'C');
     }
+
+    #[test]
+    #[should_panic(expected = "length mismatch: 3 vs 5")]
+    fn test_observer_set_all_length_mismatch() {
+        let def = AlleleDefinition::from_vector(
+            "chr22",
+            vec![48665164, 48665175, 48665182, 48665204, 48665216],
+        );
+        let mut observer = HaplotypeObserver::new(&def);
+        observer.set_all("read42", "CAT");
+    }
 }

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -16,12 +16,12 @@ impl MicrohapPanel {
         let mut definitions = HashMap::new();
         for result in reader.records() {
             let record = result?;
-            let identifier = record[0].to_owned();
-            let chrom = record[1].to_owned();
+            let identifier = &record[0];
+            let chrom = &record[1];
             let offset = record[2].parse::<u32>()?;
             let definition = definitions
-                .entry(identifier)
-                .or_insert_with(|| AlleleDefinition::new(chrom));
+                .entry(identifier.to_owned())
+                .or_insert_with(|| AlleleDefinition::new(&chrom));
             definition.add_snp_offset(offset);
         }
         Ok(MicrohapPanel { definitions })
@@ -41,7 +41,7 @@ mod tests {
             self.definitions.len()
         }
 
-        pub fn get(&self, identifier: &String) -> Option<&AlleleDefinition> {
+        pub fn get(&self, identifier: &str) -> Option<&AlleleDefinition> {
             self.definitions.get(identifier)
         }
     }
@@ -51,18 +51,9 @@ mod tests {
         let panel = MicrohapPanel::from_csv(&PathBuf::from("testdata/twomh.csv"))
             .expect("issue parsing panel CSV");
         assert_eq!(panel.len(), 2);
-
-        let id1 = "mh04WL-069".to_string();
-        let def1 = panel.get(&id1).unwrap();
-        assert_eq!(def1.extent(), 277);
-
-        let id2 = "mh13KK-223.v1".to_string();
-        let def2 = panel.get(&id2).unwrap();
-        assert_eq!(def2.extent(), 154);
-
-        let id3 = "mh02KK-138.v2".to_string();
-        let def3 = panel.get(&id3);
-        assert!(def3.is_none());
+        assert_eq!(panel.get("mh04WL-069").unwrap().extent(), 277);
+        assert_eq!(panel.get("mh13KK-223.v1").unwrap().extent(), 154);
+        assert!(panel.get("mh02KK-138.v2").is_none());
     }
 
     #[test]

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,0 +1,60 @@
+use crate::thresholds::{AnalyticalThreshold, DetectionThreshold};
+use csv::ReaderBuilder;
+use std::path::PathBuf;
+
+pub struct TypingParameters {
+    pub detection_threshold: DetectionThreshold,
+    pub analytical_threshold: AnalyticalThreshold,
+    pub min_base_quality: u8,
+    pub max_depth: u32,
+}
+
+impl TypingParameters {
+    pub fn defaults() -> TypingParameters {
+        TypingParameters {
+            detection_threshold: DetectionThreshold::new(10),
+            analytical_threshold: AnalyticalThreshold::new(0.04),
+            min_base_quality: 10,
+            max_depth: 1e6 as u32,
+        }
+    }
+
+    pub fn new(
+        detection_global: u16,
+        analytical_global: f64,
+        min_base_quality: u8,
+        max_depth: u32,
+        thresholds_file: Option<&PathBuf>,
+    ) -> TypingParameters {
+        let mut params = TypingParameters {
+            detection_threshold: DetectionThreshold::new(detection_global),
+            analytical_threshold: AnalyticalThreshold::new(analytical_global),
+            min_base_quality,
+            max_depth,
+        };
+        match thresholds_file {
+            None => (),
+            Some(csv_path) => params.parse_thresholds_csv(csv_path),
+        };
+
+        params
+    }
+
+    fn parse_thresholds_csv(&mut self, csv_path: &PathBuf) {
+        let mut reader = ReaderBuilder::new()
+            .from_path(csv_path)
+            .expect("error parsing CSV file");
+        for result in reader.records() {
+            let record = result.expect("error parsing CSV record");
+            let marker = &record[0];
+            let static_th = record[1]
+                .parse::<u16>()
+                .expect("error parsing detection threshold");
+            let dynamic_th = record[2]
+                .parse::<f64>()
+                .expect("error parsing analytical threshold");
+            self.detection_threshold.insert(marker, static_th);
+            self.analytical_threshold.insert(marker, dynamic_th);
+        }
+    }
+}

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -20,15 +20,15 @@ impl TypingParameters {
     }
 
     pub fn new(
-        detection_global: u16,
-        analytical_global: f64,
+        detection_default: u16,
+        analytical_default: f64,
         min_base_quality: u8,
         max_depth: u32,
         thresholds_file: Option<&PathBuf>,
     ) -> TypingParameters {
         let mut params = TypingParameters {
-            detection_threshold: DetectionThreshold::new(detection_global),
-            analytical_threshold: AnalyticalThreshold::new(analytical_global),
+            detection_threshold: DetectionThreshold::new(detection_default),
+            analytical_threshold: AnalyticalThreshold::new(analytical_default),
             min_base_quality,
             max_depth,
         };
@@ -56,5 +56,46 @@ impl TypingParameters {
             self.detection_threshold.insert(marker, static_th);
             self.analytical_threshold.insert(marker, dynamic_th);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_typing_parameters_defaults() {
+        let params = TypingParameters::defaults();
+        assert_eq!(params.min_base_quality, 10);
+        assert_eq!(params.max_depth, 1000000);
+        assert_eq!(params.detection_threshold.get("mh13KK-221.v1"), 10);
+        assert_eq!(params.analytical_threshold.get("mh13KK-221.v1"), 0.04);
+    }
+
+    #[test]
+    fn test_typing_parameters_basic() {
+        let params = TypingParameters::new(15, 0.032, 20, 50000, None);
+        assert_eq!(params.min_base_quality, 20);
+        assert_eq!(params.max_depth, 50000);
+        assert_eq!(params.detection_threshold.get("mh13KK-221.v1"), 15);
+        assert_eq!(params.analytical_threshold.get("mh13KK-221.v1"), 0.032);
+    }
+
+    #[test]
+    fn test_typing_parameters_csv() {
+        let csv = PathBuf::from("testdata/mwgfour-thresholds.csv");
+        let params = TypingParameters::new(12, 0.024, 16, 64000, Some(&csv));
+        assert_eq!(params.min_base_quality, 16);
+        assert_eq!(params.max_depth, 64000);
+        assert_eq!(params.detection_threshold.get("mh03USC-3qC.v2"), 10);
+        assert_eq!(params.analytical_threshold.get("mh03USC-3qC.v2"), 0.039);
+        assert_eq!(params.detection_threshold.get("mh04WL-052.v1"), 10);
+        assert_eq!(params.analytical_threshold.get("mh04WL-052.v1"), 0.031);
+        assert_eq!(params.detection_threshold.get("mh06SCUZJ-0528857"), 20);
+        assert_eq!(params.analytical_threshold.get("mh06SCUZJ-0528857"), 0.041);
+        assert_eq!(params.detection_threshold.get("mh17FHL-005.v3"), 10);
+        assert_eq!(params.analytical_threshold.get("mh17FHL-005.v3"), 0.027);
+        assert_eq!(params.detection_threshold.get("mh05KK-170.v3"), 12);
+        assert_eq!(params.analytical_threshold.get("mh05KK-170.v3"), 0.024);
     }
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -13,9 +13,9 @@ pub struct MicrohapProfile {
 }
 
 impl MicrohapProfile {
-    pub fn new(sample_id: String) -> MicrohapProfile {
+    pub fn new(sample_id: &str) -> MicrohapProfile {
         MicrohapProfile {
-            sample_id,
+            sample_id: sample_id.to_string(),
             results: BTreeMap::new(),
         }
     }
@@ -26,6 +26,10 @@ impl MicrohapProfile {
 
     pub fn to_json(&self) -> String {
         serde_json::to_string_pretty(self).expect("Failed to serialize MicrohapProfile to JSON")
+    }
+
+    pub fn get(&self, mhid: &str) -> Option<&TypingResult> {
+        self.results.get(mhid)
     }
 }
 
@@ -51,7 +55,7 @@ mod tests {
 
     #[test]
     fn test_profile_basic() {
-        let mut profile = MicrohapProfile::new("s1".to_string());
+        let mut profile = MicrohapProfile::new("s1");
         assert_eq!(profile.results.len(), 0);
         let result = TypingResult::from_file("testdata/dummy-result.json");
         profile.add("mh17FHL-005.v3", result);

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -27,10 +27,6 @@ impl MicrohapProfile {
     pub fn to_json(&self) -> String {
         serde_json::to_string_pretty(self).expect("Failed to serialize MicrohapProfile to JSON")
     }
-
-    pub fn get(&self, mhid: &str) -> Option<&TypingResult> {
-        self.results.get(mhid)
-    }
 }
 
 #[cfg(test)]
@@ -50,6 +46,10 @@ mod tests {
             file.read_to_string(&mut data).expect("Failed to read file");
 
             MicrohapProfile::from_json(&data).expect("Failed to parse TypingResult from JSON")
+        }
+
+        pub fn get(&self, mhid: &str) -> Option<&TypingResult> {
+            self.results.get(mhid)
         }
     }
 

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -65,7 +65,7 @@ mod tests {
         assert_eq!(profile.results.len(), 4);
         let (mhid, result) = profile.results.iter().next().expect("iter fail");
         assert_eq!(mhid, "mh03USC-3qC.v2");
-        assert_eq!(result.thresholds.dynamic_analytical, 92.08);
+        assert_eq!(result.thresholds.analytical, 92.08);
         let json = profile.to_json();
         assert!(json.contains("mh06SCUZJ-0528857"));
         assert!(json.contains("\"ACCGGGCTC\": 1180,"));

--- a/src/result.rs
+++ b/src/result.rs
@@ -4,6 +4,7 @@ extern crate serde_json;
 
 use crate::counter::ReadHapCounter;
 use crate::read::ReadHaplotype;
+use crate::thresholds::TypingThresholds;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -20,14 +21,6 @@ pub struct TypingCoverage {
     pub max: u32,
     pub mean: f64,
     pub min: u32,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TypingThresholds {
-    #[serde(rename = "dynamic")]
-    pub dynamic_analytical: f64,
-    #[serde(rename = "static")]
-    pub static_detection: u16,
 }
 
 #[cfg(test)]

--- a/src/result.rs
+++ b/src/result.rs
@@ -52,7 +52,7 @@ mod tests {
 
     fn init_caller() -> HaplotypeCaller {
         let def = AlleleDefinition::from_vector(
-            "chr22".to_string(),
+            "chr22",
             vec![48665164, 48665175, 48665182, 48665204, 48665216],
         );
         let mut observer = HaplotypeObserver::new(&def);

--- a/src/thresholds.rs
+++ b/src/thresholds.rs
@@ -1,0 +1,39 @@
+extern crate serde;
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TypingThresholds {
+    pub dynamic: f64,
+    pub analytical: f64,
+    pub detection: u16,
+}
+
+pub struct ReadCountThreshold<T> {
+    pub default: T,
+    by_marker: HashMap<String, T>,
+}
+
+impl<T: Clone> ReadCountThreshold<T> {
+    pub fn new(default: T) -> ReadCountThreshold<T> {
+        ReadCountThreshold {
+            default,
+            by_marker: HashMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, marker_id: &str, threshold: T) {
+        self.by_marker.insert(marker_id.to_string(), threshold);
+    }
+
+    pub fn get(&self, marker_id: &str) -> T {
+        match self.by_marker.get(marker_id) {
+            Some(threshold) => threshold.clone(),
+            None => self.default.clone(),
+        }
+    }
+}
+
+pub type DetectionThreshold = ReadCountThreshold<u16>;
+pub type AnalyticalThreshold = ReadCountThreshold<f64>;

--- a/src/thresholds.rs
+++ b/src/thresholds.rs
@@ -11,7 +11,7 @@ pub struct TypingThresholds {
 }
 
 pub struct ReadCountThreshold<T> {
-    pub default: T,
+    default: T,
     by_marker: HashMap<String, T>,
 }
 
@@ -37,3 +37,28 @@ impl<T: Clone> ReadCountThreshold<T> {
 
 pub type DetectionThreshold = ReadCountThreshold<u16>;
 pub type AnalyticalThreshold = ReadCountThreshold<f64>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detection_threshold() {
+        let mut t = DetectionThreshold::new(42);
+        t.insert("mh09USC-9qC", 5);
+        t.insert("mh10WL-031", 15);
+        assert_eq!(t.get("mh09USC-9qC"), 5);
+        assert_eq!(t.get("mh10WL-031"), 15);
+        assert_eq!(t.get("mh04SHY-004"), 42);
+    }
+
+    #[test]
+    fn test_analytical_threshold() {
+        let mut t = AnalyticalThreshold::new(0.042);
+        t.insert("mh13KK-221.v1", 0.033);
+        t.insert("mh19USC-19qB.v2", 0.029);
+        assert_eq!(t.get("mh13KK-221.v1"), 0.033);
+        assert_eq!(t.get("mh19USC-19qB.v2"), 0.029);
+        assert_eq!(t.get("mh09WL-034"), 0.042);
+    }
+}

--- a/testdata/dummy-result.json
+++ b/testdata/dummy-result.json
@@ -10,8 +10,9 @@
   },
   "num_discarded": 95,
   "thresholds": {
-    "dynamic": 94.68,
-    "static": 10
+    "dynamic": 0.04,
+    "analytical": 94.68,
+    "detection": 10
   },
   "counts": {
     "AGTTTC": 3,

--- a/testdata/mwgfour-p1-profile.json
+++ b/testdata/mwgfour-p1-profile.json
@@ -12,8 +12,9 @@
       },
       "num_discarded": 138,
       "thresholds": {
-        "dynamic": 92.88,
-        "static": 10
+        "dynamic": 0.04,
+        "analytical": 92.88,
+        "detection": 10
       },
       "counts": {
         "CCACTGC": 2,
@@ -34,8 +35,9 @@
       },
       "num_discarded": 103,
       "thresholds": {
-        "dynamic": 94.0,
-        "static": 10
+        "dynamic": 0.04,
+        "analytical": 94.0,
+        "detection": 10
       },
       "counts": {
         "ACCAAGCCC": 1178,
@@ -60,8 +62,9 @@
       },
       "num_discarded": 42,
       "thresholds": {
-        "dynamic": 97.24000000000001,
-        "static": 10
+        "dynamic": 0.04,
+        "analytical": 97.24000000000001,
+        "detection": 10
       },
       "counts": {
         "AACTGTC": 1211,
@@ -80,8 +83,9 @@
       },
       "num_discarded": 113,
       "thresholds": {
-        "dynamic": 93.88,
-        "static": 10
+        "dynamic": 0.04,
+        "analytical": 93.88,
+        "detection": 10
       },
       "counts": {
         "ACCCAT": 1,

--- a/testdata/mwgfour-p1p3-profile.json
+++ b/testdata/mwgfour-p1p3-profile.json
@@ -13,8 +13,9 @@
       },
       "num_discarded": 150,
       "thresholds": {
-        "dynamic": 93.0,
-        "static": 10
+        "dynamic": 0.04,
+        "analytical": 93.0,
+        "detection": 10
       },
       "counts": {
         "CCACTGC": 5,
@@ -37,8 +38,9 @@
       },
       "num_discarded": 91,
       "thresholds": {
-        "dynamic": 95.08,
-        "static": 10
+        "dynamic": 0.04,
+        "analytical": 95.08,
+        "detection": 10
       },
       "counts": {
         "ACCAAGCCA": 1,
@@ -66,8 +68,9 @@
       },
       "num_discarded": 47,
       "thresholds": {
-        "dynamic": 97.36,
-        "static": 10
+        "dynamic": 0.04,
+        "analytical": 97.36,
+        "detection": 10
       },
       "counts": {
         "AACTGTC": 1033,
@@ -89,8 +92,9 @@
       },
       "num_discarded": 89,
       "thresholds": {
-        "dynamic": 95.16,
-        "static": 10
+        "dynamic": 0.04,
+        "analytical": 95.16,
+        "detection": 10
       },
       "counts": {
         "ACCCGT": 1,

--- a/testdata/mwgfour-p2-profile.json
+++ b/testdata/mwgfour-p2-profile.json
@@ -13,8 +13,9 @@
       },
       "num_discarded": 146,
       "thresholds": {
-        "dynamic": 92.08,
-        "static": 10
+        "dynamic": 0.04,
+        "analytical": 92.08,
+        "detection": 10
       },
       "counts": {
         "CCACGGG": 1,
@@ -41,8 +42,9 @@
       },
       "num_discarded": 98,
       "thresholds": {
-        "dynamic": 94.44,
-        "static": 10
+        "dynamic": 0.04,
+        "analytical": 94.44,
+        "detection": 10
       },
       "counts": {
         "ACCGGGCTC": 1180,
@@ -62,8 +64,9 @@
       },
       "num_discarded": 28,
       "thresholds": {
-        "dynamic": 97.32000000000001,
-        "static": 10
+        "dynamic": 0.04,
+        "analytical": 97.32000000000001,
+        "detection": 10
       },
       "counts": {
         "GACCATC": 1,
@@ -89,8 +92,9 @@
       },
       "num_discarded": 95,
       "thresholds": {
-        "dynamic": 94.68,
-        "static": 10
+        "dynamic": 0.04,
+        "analytical": 94.68,
+        "detection": 10
       },
       "counts": {
         "AGTTTC": 3,

--- a/testdata/mwgfour-thresholds.csv
+++ b/testdata/mwgfour-thresholds.csv
@@ -1,0 +1,5 @@
+Marker,Detection,Analytical
+mh03USC-3qC.v2,10,0.039
+mh04WL-052.v1,10,0.031
+mh06SCUZJ-0528857,20,0.041
+mh17FHL-005.v3,10,0.027


### PR DESCRIPTION
This branch adds support for marker-specific typing thresholds provided as a CSV file. Related data structures and modules were refactored to facilitate this feature.

Additional updates include the following:
- Additional tests
- Streamlined and consistent handling of `String` and `&str` objects to ensure ownership without undue copying
- Improved CI configuration
- Exposed `--max-depth` parameter to the command line, previously hard-coded internally as 1,000,000.